### PR TITLE
INTG 309 - Export media option

### DIFF
--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -12,6 +12,7 @@ import time
 import errno
 from datetime import datetime
 import requests
+import shutil
 
 DEFAULT_EXPORT_TIMEZONE = 'Etc/UTC'
 DEFAULT_EXPORT_FORMAT = 'pdf'
@@ -314,6 +315,11 @@ class SafetyCulture:
 
         export_content = self.download_export(export_href)
         return export_content
+
+    def get_media(self, audit_id, media_id):
+        url = self.audit_url + audit_id + '/media/' + media_id
+        response = requests.get(url, headers=self.custom_http_headers, stream=True)
+        return response
 
     def get_audit(self, audit_id):
         """

--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -12,7 +12,6 @@ import time
 import errno
 from datetime import datetime
 import requests
-import shutil
 
 DEFAULT_EXPORT_TIMEZONE = 'Etc/UTC'
 DEFAULT_EXPORT_FORMAT = 'pdf'
@@ -317,6 +316,13 @@ class SafetyCulture:
         return export_content
 
     def get_media(self, audit_id, media_id):
+        """
+        Request media item associated with a specified audit and media ID
+        :param audit_id:    audit ID of document that contains media 
+        :param media_id:    media ID of image to fetch
+        :return:            The Content-Type will be the MIME type associated with the media, 
+                            and the body of the response is the media itself.
+        """
         url = self.audit_url + audit_id + '/media/' + media_id
         response = requests.get(url, headers=self.custom_http_headers, stream=True)
         return response

--- a/tools/exporter/ReadMe.md
+++ b/tools/exporter/ReadMe.md
@@ -58,7 +58,7 @@ To export a single Audit:
 python exporter.py --format json
 python csvExporter.py path/to/audit_file.json
 ```
-* Basic example of [CSV Export Format](https://github.com/SafetyCulture/safetyculture-sdk-python/blob/INTG-174_CSVExport/tools/exporter/tests/csv_test_files/unit_test_single_question_yes___no___na_answered_yes_expected_output.csv)
+* Basic example of [CSV Export Format](https://github.com/SafetyCulture/safetyculture-sdk-python/blob/master/tools/exporter/tests/csv_test_files/unit_test_single_question_yes___no___na_answered_no_expected_output.csv)
 
 #### Bulk CSV Export
 * Each Audit is the same format as the single Audit CSV export

--- a/tools/exporter/ReadMe.md
+++ b/tools/exporter/ReadMe.md
@@ -2,7 +2,7 @@
 
 Allows you to export audit data from the SafetyCulture Platform and save them anywhere on your computer.
 
-Supported export formats: PDF, MS WORD (docx), JSON, and CSV. Media exporting are also supported.
+Supported export formats: PDF, MS WORD (docx), JSON, and CSV. Media exporting is also supported.
 
 ## Installation
 
@@ -65,7 +65,7 @@ python csvExporter.py path/to/audit_file.json
 * Audits are grouped by Template. Audits built from the same template are appended to a CSV file named using the templates unique ID number.
 
 To export Multiple Audits to Bulk CSV file:
-* Execute Exporter.py with the format option set to CSV
+* Execute exporter.py with the format option set to CSV
 ```
 python exporter.py --format csv
 ```

--- a/tools/exporter/ReadMe.md
+++ b/tools/exporter/ReadMe.md
@@ -2,7 +2,7 @@
 
 Allows you to export audit data from the SafetyCulture Platform and save them anywhere on your computer.
 
-Supported export formats: PDF, MS WORD (docx), JSON
+Supported export formats: PDF, MS WORD (docx), JSON, and CSV. Media exporting are also supported.
 
 ## Installation
 
@@ -40,7 +40,7 @@ python exporter.py --format pdf
 More than one supported formats can be exported at once e.g.
 
 ```
-python exporter.py --format pdf docx json csv
+python exporter.py --format pdf docx json csv media
 ```
 
 Note:
@@ -65,7 +65,7 @@ python csvExporter.py path/to/audit_file.json
 * Audits are grouped by Template. Audits built from the same template are appended to a CSV file named using the templates unique ID number.
 
 To export Multiple Audits to Bulk CSV file:
-1. Execute Exporter.py with the format option set to CSV 
+* Execute Exporter.py with the format option set to CSV
 ```
 python exporter.py --format csv
 ```
@@ -83,6 +83,9 @@ python exporter.py --format csv
 #### Bulk CSV Export Gotchas
 * If you update an Audit that has already been exported, it may be appended to the CSV file a second time.
 * If you update a template, Audits with the new format will be appended to the same CSV file.
+
+### Media Export
+* Executing ```python exporter.py --format media``` will export all audit media files for each audit (images, attachments, signature, and drawings) to a folder named after the audit ID.
 
 
 ## Export settings

--- a/tools/exporter/csvExporter.py
+++ b/tools/exporter/csvExporter.py
@@ -448,7 +448,6 @@ class CsvExporter:
 
     def get_item_location_coordinates(self, item):
         """
-
         :param item:    single item in JSON format
         :return:        comma separated longitude and latitude coordinates
         """
@@ -462,7 +461,6 @@ class CsvExporter:
     def item_properties_as_list(self, item):
         """
         Returns selected properties of the audit item JSON as a list
-
         :param item:    single item in JSON format
         :return:        array of item data, in format that CSV writer can handle
         """

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -14,6 +14,7 @@ import datetime
 import dateutil.parser
 import yaml
 import pytz
+import shutil
 from tzlocal import get_localzone
 import csvExporter as csv
 
@@ -248,6 +249,25 @@ def create_directory_if_not_exists(logger, path):
             log_critical_error(logger, ex, 'An error happened trying to create ' + path)
             raise
 
+def save_exported_media_to_file(logger, export_dir, export_doc, filename, extension):
+    """
+    Write exported media item to disk at specified location with specified file name.
+    Any existing file with the same name will be overwritten.
+    :param logger:      the logger
+    :param export_dir:  path to directory for exports
+    :param export_doc:  media file to write to disc
+    :param filename:    filename to give exported image
+    :param extension:   extension to give exported image
+    """
+    file_path = os.path.join(export_dir, filename + '.' + extension)
+    if os.path.isfile(file_path):
+        logger.info('Overwriting existing report at ' + file_path)
+    try:
+        with open(file_path, 'wb') as out_file:
+            shutil.copyfileobj(export_doc.raw, out_file)
+        del export_doc
+    except Exception as ex:
+        log_critical_error(logger, ex, 'Exception while writing' + file_path + ' to file')
 
 def save_exported_document(logger, export_dir, export_doc, filename, extension):
     """

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -582,14 +582,14 @@ def get_media_from_audit(logger, audit_json):
     """
     media_id_list = []
     for item in audit_json['header_items'] + audit_json['items']:
-        # media field, question field. List of media
+        # This condition checks for media attached to question and media type fields.
         if 'media' in item.keys():
             for media in item['media']:
                 media_id_list.append(media['media_id'])
-        # Signature field, drawing field. Object, single media
+        # This condition checks for media attached to signature and drawing type fields.
         if 'responses' in item.keys() and 'image' in item['responses'].keys():
             media_id_list.append(item['responses']['image']['media_id'])
-        # Information field. Object, single media.
+        # This condition checks for media attached to information type fields. 
         if 'options' in item.keys() and 'media' in item['options'].keys():
             media_id_list.append(item['options']['media']['media_id'])
     logger.info("Discovered {0} media files associated with {1}.".format(len(media_id_list), audit_json['audit_id']))

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -556,7 +556,7 @@ def sync_exports(logger, sc_client, settings):
                         csv_exporter.append_converted_audit_to_bulk_export_file(os.path.join(export_path, csv_export_filename + '.csv'))
                         continue
                     elif export_format == 'media':
-                        media_export_path = os.path.join(export_path, 'media', audit_id)
+                        media_export_path = os.path.join(export_path, 'media', export_filename)
                         extension = 'jpg'
                         media_id_list = get_media_from_audit(logger, audit_json)
                         if len(media_id_list) == 0:


### PR DESCRIPTION
Added ability to export media files.
By default, media files are stored in  `exports/media/<audit_id>/`
The readMe file has been updated to reflect new functionality. 

Example command : 
`$python exporter.py --format pdf csv media`