### PR TITLE
updated looping function to use correct sync-delay-in-seconds variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name = 'safetyculture-sdk-python',
-      version = '3.1.1',
+      version = '3.1.3',
       description = 'iAuditor Python SDK and integration tools',
       url = 'https://github.com/SafetyCulture/safetyculture-sdk-python',
       author = 'SafetyCulture',

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -926,7 +926,7 @@ def loop(logger, sc_client, settings):
     :param sc_client:  instance of SafetyCulture SDK object
     :param settings:   dictionary containing config settings values
     """
-    sync_delay_in_seconds = load_setting_sync_delay(logger, settings)
+    sync_delay_in_seconds = settings[SYNC_DELAY_IN_SECONDS]
     while True:
         sync_exports(logger, settings, sc_client)
         logger.info('Next check will be in ' + str(sync_delay_in_seconds) + ' seconds. Waiting...')


### PR DESCRIPTION
This function:
def loop(logger, sc_client, settings):
```
    """
    Loop sync until interrupted by user
    :param logger:     the logger
    :param sc_client:  instance of SafetyCulture SDK object
    :param settings:   dictionary containing config settings values
    """
    sync_delay_in_seconds = load_setting_sync_delay(logger, settings)
    while True:
        sync_exports(logger, settings, sc_client)
        logger.info('Next check will be in ' + str(sync_delay_in_seconds) + ' seconds. Waiting...')
        time.sleep(sync_delay_in_seconds)
```
was sending the object 'settings' to the function 'load_setting_sync_delay'. This is incorrect as settings is a flattened version of the configuration file properties. 'load_setting_sync_delay' expects the configuration file information. This function should be using the value already saved in 'settings' rather than calling 'load_setting_sync_delay' again.