### PR TITLE
Intg 763 export completed actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -193,7 +193,7 @@ Things you can configure:
 
 |  Setting | Description  |
 |---|---|
-| hosting_region | the region your iAuditor data is hosted. Defaults to US. Can be one of US, AU, EU, or UK | 
+| hosting_region | the region your iAuditor data is hosted. Can be US or AU. Defaults to US. |
 | export_path  | absolute or relative path to the directory where to save exported data to  |
 | timezone |  an Olson timezone to be used in generated audit reports. If invalid or missing, reports will use the timezone local to the computer running the export tool |
 | filename  |  an audit item ID whose response is going to be used to name the files of exported audit reports. Can only be an item with a response type of `text` from the header section of the audit such as Audit Title, Document No., Client / Site, Prepared By, Personnel, or any custom header item which has a 'text' type response |

--- a/README.md
+++ b/README.md
@@ -193,6 +193,7 @@ Things you can configure:
 
 |  Setting | Description  |
 |---|---|
+| hosting_region | the region your iAuditor data is hosted. Defaults to US. Can be one of US, AU, EU, or UK | 
 | export_path  | absolute or relative path to the directory where to save exported data to  |
 | timezone |  an Olson timezone to be used in generated audit reports. If invalid or missing, reports will use the timezone local to the computer running the export tool |
 | filename  |  an audit item ID whose response is going to be used to name the files of exported audit reports. Can only be an item with a response type of `text` from the header section of the audit such as Audit Title, Document No., Client / Site, Prepared By, Personnel, or any custom header item which has a 'text' type response |
@@ -206,19 +207,20 @@ Here is an example customised config.yaml:
 ```
 API:
     token: YOUR_IAUDITOR_API_TOKEN
+    hosting_regions: US
 export_options:
     export_path: /Users/Monty/Dropbox
     timezone: America/Chicago
     filename: f3245d40-ea77-11e1-aff1-0800200c9a66
     csv:
         export_inactive_items: false
-export_profiles:
-    template_3E631E46F466411B9C09AD804886A8B4:E15A6525-EFA5-4835-92F0-D11CA9F364F3
-    template_3E631E46F466411B9C09AD804886A8B4:E50645A1-2851-4E92-B4EA-60C5CE7981BE
-    ...
-    ...
-sync_delay_in_seconds: 36000
-media_sync_offset_in_seconds: 600
+    export_profiles:
+        template_3E631E46F466411B9C09AD804886A8B4:E15A6525-EFA5-4835-92F0-D11CA9F364F3
+        template_3E631E46F466411B9C09AD804886A8B4:E50645A1-2851-4E92-B4EA-60C5CE7981BE
+        ...
+        ...
+    sync_delay_in_seconds: 36000
+    media_sync_offset_in_seconds: 600
 ```
 
 Note: Templates for which there is no export profile id listed in the config file will be exported without a profile applied

--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -21,7 +21,7 @@ GUID_PATTERN = '[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-F
 HTTP_USER_AGENT_ID = 'safetyculture-python-sdk'
 
 # accepted configuration options for hosting region.
-# hosting region specifies which datacenter the customers data is stored at.
+# hosting region specifies which datacenter the customer's data is stored at
 USA = 'US'
 AUSTRALIA = 'AU'
 

--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -395,7 +395,11 @@ class SafetyCulture:
         actions_url = self.api_url + 'actions/search'
         response = self.authenticated_request_post(
             actions_url,
-            data=json.dumps({"modified_at": {"from": str(date_modified)}, "offset": offset})
+            data=json.dumps({
+                "modified_at": {"from": str(date_modified)},
+                "offset": offset,
+                "status": [0, 10, 50, 60]
+            })
         )
         result = self.parse_json(response.content) if response.status_code == requests.codes.ok else None
         self.log_http_status(response.status_code, 'GET actions')

--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -44,13 +44,17 @@ def get_user_api_token(logger):
 
 
 class SafetyCulture:
-    def __init__(self, api_token, api_region):
+    def __init__(self, api_token, api_region='usa'):
         self.current_dir = os.getcwd()
         self.log_dir = self.current_dir + '/log/'
 
-        # logic will go here to make the url dependent upon the API Region
-        # Region can be usa, aus, or uk
-        self.api_url = 'https://api.safetyculture.io/'
+        if api_region == 'usa':
+            self.api_url = 'https://api.safetyculture.io/'
+        elif api_region == 'uk':
+            pass
+        elif api_region == 'aus':
+            pass
+
         self.audit_url = self.api_url + 'audits/'
         self.template_search_url = self.api_url + 'templates/search?field=template_id&field=name'
         self.response_set_url = self.api_url + 'response_sets'

--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -20,6 +20,12 @@ DEFAULT_EXPORT_FORMAT = 'pdf'
 GUID_PATTERN = '[A-Fa-f0-9]{8}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{4}-[A-Fa-f0-9]{12}$'
 HTTP_USER_AGENT_ID = 'safetyculture-python-sdk'
 
+# accepted configuration options for hosting region.
+# hosting region specifies which datacenter the customers data is stored at.
+USA = 'US'
+AUSTRALIA = 'AU'
+EUROPE = 'EU'
+UNITED_KINGDOM = 'UK'
 
 def get_user_api_token(logger):
     """
@@ -44,16 +50,17 @@ def get_user_api_token(logger):
 
 
 class SafetyCulture:
-    def __init__(self, api_token, api_region='usa'):
+    def __init__(self, api_token, api_region=USA):
         self.current_dir = os.getcwd()
         self.log_dir = self.current_dir + '/log/'
-
-        if api_region == 'usa':
+        if api_region == USA:
             self.api_url = 'https://api.safetyculture.io/'
-        elif api_region == 'uk':
-            pass
-        elif api_region == 'aus':
-            pass
+        elif api_region == UNITED_KINGDOM:
+            self.api_url = 'https://api.safetyculture.io/'
+        elif api_region == AUSTRALIA:
+            self.api_url = 'https://api.safetyculture.io/'
+        elif api_region == EUROPE:
+            self.api_url = 'https://api.safetyculture.io/'
 
         self.audit_url = self.api_url + 'audits/'
         self.template_search_url = self.api_url + 'templates/search?field=template_id&field=name'

--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -44,10 +44,12 @@ def get_user_api_token(logger):
 
 
 class SafetyCulture:
-    def __init__(self, api_token):
+    def __init__(self, api_token, api_region):
         self.current_dir = os.getcwd()
         self.log_dir = self.current_dir + '/log/'
 
+        # logic will go here to make the url dependent upon the API Region
+        # Region can be usa, aus, or uk
         self.api_url = 'https://api.safetyculture.io/'
         self.audit_url = self.api_url + 'audits/'
         self.template_search_url = self.api_url + 'templates/search?field=template_id&field=name'

--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -55,11 +55,7 @@ class SafetyCulture:
         self.log_dir = self.current_dir + '/log/'
         if api_region == USA:
             self.api_url = 'https://api.safetyculture.io/'
-        elif api_region == UNITED_KINGDOM:
-            self.api_url = 'https://api.safetyculture.io/'
         elif api_region == AUSTRALIA:
-            self.api_url = 'https://api.safetyculture.io/'
-        elif api_region == EUROPE:
             self.api_url = 'https://api.safetyculture.io/'
 
         self.audit_url = self.api_url + 'audits/'

--- a/safetypy/safetypy.py
+++ b/safetypy/safetypy.py
@@ -24,8 +24,6 @@ HTTP_USER_AGENT_ID = 'safetyculture-python-sdk'
 # hosting region specifies which datacenter the customers data is stored at.
 USA = 'US'
 AUSTRALIA = 'AU'
-EUROPE = 'EU'
-UNITED_KINGDOM = 'UK'
 
 def get_user_api_token(logger):
     """
@@ -56,7 +54,7 @@ class SafetyCulture:
         if api_region == USA:
             self.api_url = 'https://api.safetyculture.io/'
         elif api_region == AUSTRALIA:
-            self.api_url = 'https://api.safetyculture.io/'
+            self.api_url = 'https://api.au.safetyculture.com/'
 
         self.audit_url = self.api_url + 'audits/'
         self.template_search_url = self.api_url + 'templates/search?field=template_id&field=name'

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name = 'safetyculture-sdk-python',
-      version = '3.1.1',
+      version = '3.1.2',
       description = 'iAuditor Python SDK and integration tools',
       url = 'https://github.com/SafetyCulture/safetyculture-sdk-python',
       author = 'SafetyCulture',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name = 'safetyculture-sdk-python',
-      version = '3.2.0',
+      version = '3.1.4',
       description = 'iAuditor Python SDK and integration tools',
       url = 'https://github.com/SafetyCulture/safetyculture-sdk-python',
       author = 'SafetyCulture',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name = 'safetyculture-sdk-python',
-      version = '3.1.2',
+      version = '3.2.0',
       description = 'iAuditor Python SDK and integration tools',
       url = 'https://github.com/SafetyCulture/safetyculture-sdk-python',
       author = 'SafetyCulture',

--- a/tools/exporter/config.yaml
+++ b/tools/exporter/config.yaml
@@ -1,5 +1,6 @@
 API:
     token: YOUR_IAUDITOR_API_TOKEN
+    region:
 export_options:
     export_path:
     timezone:

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -596,7 +596,7 @@ def configure(logger, path_to_config_file, export_formats):
 
     config_settings = load_config_settings(logger, path_to_config_file)
     config_settings[EXPORT_FORMATS] = export_formats
-    sc_client = sp.SafetyCulture(config_settings[API_TOKEN])
+    sc_client = sp.SafetyCulture(config_settings[API_TOKEN], config_settings[REGION])
 
     if config_settings[EXPORT_PATH] is not None:
         create_directory_if_not_exists(logger, config_settings[EXPORT_PATH])

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -52,8 +52,6 @@ EMPTY_RESPONSE = ''
 # hosting region specifies which datacenter the customers data is stored at.
 USA = 'US'
 AUSTRALIA = 'AU'
-EUROPE = 'EU'
-UNITED_KINGDOM = 'UK'
 
 # default hosting region
 DEFAULT_HOSTING_REGION = USA

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -129,7 +129,7 @@ def load_settings_region(logger, config_settings):
             return region
         else:
             logger.warning('No valid region specified in config file. Must be one of "usa", "aus", or "uk".')
-            logger.info('API region defaulting to ' + DEFAULT_REGION)
+            logger.info('API region defaulting to "' + DEFAULT_REGION + '"')
             return DEFAULT_REGION
     except Exception as ex:
         log_critical_error(logger, ex, 'Exception parsing API region from config.yaml. Defaulting to default: ' + DEFAULT_REGION)

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -124,11 +124,12 @@ def load_settings_region(logger, config_settings):
     """
     try:
         region = config_settings['API']['region']
-        if region in ['usa', 'aus', 'uk']:
-            logger.debug('Loading region from config file: ' + region)
+        if region in ['usa']:
+            logger.debug('Loading region from config file.')
+            logger.debug('Setting region to "' + region + '"')
             return region
         else:
-            logger.warning('No valid region specified in config file. Must be one of "usa", "aus", or "uk".')
+            logger.warning('No valid region specified in config file. Currently only "usa" is supported')
             logger.info('API region defaulting to "' + DEFAULT_REGION + '"')
             return DEFAULT_REGION
     except Exception as ex:

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -121,7 +121,7 @@ def load_setting_api_access_token(logger, config_settings):
         log_critical_error(logger, ex, 'Exception parsing API token from config.yaml')
         return None
 
-def load_settings_region(logger, config_settings):
+def load_setting_hosting_region(logger, config_settings):
     """
     Attempt to parse API token from config settings
 
@@ -130,7 +130,7 @@ def load_settings_region(logger, config_settings):
     :return:                 API token if valid, else None
     """
     try:
-        region = config_settings['API']['region']
+        region = config_settings['API']['region'].upper()
         if region in [USA]:
             logger.debug('Loading region from config file.')
             logger.debug('Setting region to "' + region + '"')
@@ -534,7 +534,7 @@ def parse_export_filename(header_items, filename_item_id):
     return None
 
 
-def get_filename_item_id(logger, config_settings):
+def load_setting_filename_item_id(logger, config_settings):
     """
     Attempt to parse item_id for file naming from config settings
 
@@ -580,11 +580,11 @@ def load_config_settings(logger, path_to_config_file):
     config_settings = yaml.safe_load(open(path_to_config_file))
     settings = {
         API_TOKEN: load_setting_api_access_token(logger, config_settings),
-        REGION: load_settings_region(logger, config_settings),
+        REGION: load_setting_hosting_region(logger, config_settings),
         EXPORT_PATH: load_setting_export_path(logger, config_settings),
         TIMEZONE: load_setting_export_timezone(logger, config_settings),
         EXPORT_PROFILES: load_setting_export_profile_mapping(logger, config_settings),
-        FILENAME_ITEM_ID: get_filename_item_id(logger, config_settings),
+        FILENAME_ITEM_ID: load_setting_filename_item_id(logger, config_settings),
         SYNC_DELAY_IN_SECONDS: load_setting_sync_delay(logger, config_settings),
         EXPORT_INACTIVE_ITEMS_TO_CSV: load_export_inactive_items_to_csv(logger, config_settings),
         MEDIA_SYNC_OFFSET_IN_SECONDS: load_setting_media_sync_offset(logger, config_settings)

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -45,11 +45,18 @@ ACTIONS_SYNC_MARKER_FILENAME = 'last_successful_actions_export.txt'
 # Whether to export inactive items to CSV
 DEFAULT_EXPORT_INACTIVE_ITEMS_TO_CSV = True
 
-# specifies which datacenter the customers data is stored at. Can be usa, aus, or uk
-DEFAULT_REGION = 'usa'
-
 # When exporting actions to CSV, if property is None, print this value to CSV
 EMPTY_RESPONSE = ''
+
+# accepted configuration options for hosting region.
+# hosting region specifies which datacenter the customers data is stored at.
+USA = 'US'
+AUSTRALIA = 'AU'
+EUROPE = 'EU'
+UNITED_KINGDOM = 'UK'
+
+# default hosting region
+DEFAULT_HOSTING_REGION = USA
 
 # Properties kept in settings dictionary which takes its values from config.YAML
 API_TOKEN = 'api_token'
@@ -67,7 +74,7 @@ EXPORT_FORMATS = 'export_formats'
 DEFAULT_CONFIG_FILE_YAML = [
     'API:',
     '\n    token: ',
-    '\n    region:',
+    '\n    hosting_region:',
     '\nexport_options:',
     '\n    export_path:',
     '\n    timezone:',
@@ -124,17 +131,17 @@ def load_settings_region(logger, config_settings):
     """
     try:
         region = config_settings['API']['region']
-        if region in ['usa']:
+        if region in [USA]:
             logger.debug('Loading region from config file.')
             logger.debug('Setting region to "' + region + '"')
             return region
         else:
-            logger.warning('No valid region specified in config file. Currently only "usa" is supported')
-            logger.info('API region defaulting to "' + DEFAULT_REGION + '"')
-            return DEFAULT_REGION
+            logger.warning('No valid region specified in config file. Currently only' + USA + 'is supported')
+            logger.info('API region defaulting to "' + DEFAULT_HOSTING_REGION + '"')
+            return DEFAULT_HOSTING_REGION
     except Exception as ex:
-        log_critical_error(logger, ex, 'Exception parsing API region from config.yaml. Defaulting to default: ' + DEFAULT_REGION)
-        return DEFAULT_REGION
+        log_critical_error(logger, ex, 'Exception parsing API region from config.yaml. Defaulting to default: ' + DEFAULT_HOSTING_REGION)
+        return DEFAULT_HOSTING_REGION
 
 def load_export_inactive_items_to_csv(logger, config_settings):
     """

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -45,11 +45,15 @@ ACTIONS_SYNC_MARKER_FILENAME = 'last_successful_actions_export.txt'
 # Whether to export inactive items to CSV
 DEFAULT_EXPORT_INACTIVE_ITEMS_TO_CSV = True
 
+# specifies which datacenter the customers data is stored at. Can be usa, aus, or uk
+DEFAULT_REGION = 'usa'
+
 # When exporting actions to CSV, if property is None, print this value to CSV
 EMPTY_RESPONSE = ''
 
 # Properties kept in settings dictionary which takes its values from config.YAML
 API_TOKEN = 'api_token'
+REGION = 'region'
 EXPORT_PATH = 'export_path'
 TIMEZONE = 'timezone'
 EXPORT_PROFILES = 'export_profiles'
@@ -63,6 +67,7 @@ EXPORT_FORMATS = 'export_formats'
 DEFAULT_CONFIG_FILE_YAML = [
     'API:',
     '\n    token: ',
+    '\n    region:',
     '\nexport_options:',
     '\n    export_path:',
     '\n    timezone:',
@@ -109,6 +114,26 @@ def load_setting_api_access_token(logger, config_settings):
         log_critical_error(logger, ex, 'Exception parsing API token from config.yaml')
         return None
 
+def load_settings_region(logger, config_settings):
+    """
+    Attempt to parse API token from config settings
+
+    :param logger:           the logger
+    :param config_settings:  config settings loaded from config file
+    :return:                 API token if valid, else None
+    """
+    try:
+        region = config_settings['API']['region']
+        if region in ['usa', 'aus', 'uk']:
+            logger.debug('Loading region from config file: ' + region)
+            return region
+        else:
+            logger.warning('No valid region specified in config file. Must be one of "usa", "aus", or "uk".')
+            logger.info('API region defaulting to ' + DEFAULT_REGION)
+            return DEFAULT_REGION
+    except Exception as ex:
+        log_critical_error(logger, ex, 'Exception parsing API region from config.yaml. Defaulting to default: ' + DEFAULT_REGION)
+        return DEFAULT_REGION
 
 def load_export_inactive_items_to_csv(logger, config_settings):
     """
@@ -547,6 +572,7 @@ def load_config_settings(logger, path_to_config_file):
     config_settings = yaml.safe_load(open(path_to_config_file))
     settings = {
         API_TOKEN: load_setting_api_access_token(logger, config_settings),
+        REGION: load_settings_region(logger, config_settings),
         EXPORT_PATH: load_setting_export_path(logger, config_settings),
         TIMEZONE: load_setting_export_timezone(logger, config_settings),
         EXPORT_PROFILES: load_setting_export_profile_mapping(logger, config_settings),

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -368,15 +368,17 @@ def save_exported_actions_to_csv_file(logger, export_path, actions_array):
     filename = ACTIONS_EXPORT_FILENAME
     file_path = os.path.join(export_path, filename)
     logger.info('Exporting ' + str(len(actions_array)) + ' actions to ' + file_path)
-    file_path = os.path.join(export_path, filename)
-    actions_csv = open(file_path, 'ab')
-    actions_csv_wr = csv.writer(actions_csv, dialect='excel', quoting=csv.QUOTE_ALL)
-    actions_csv_wr.writerow([
-        'actionId', 'description', 'assignee', 'priority', 'priorityCode', 'status', 'statusCode', 'dueDatetime',
-        'audit', 'auditId', 'linkedToItem', 'linkedToItemId', 'creatorName', 'creatorId', 'createdDatetime',
-        'modifiedDatetime', 'completedDatetime'
-    ])
-
+    if os.path.isfile(file_path):
+        actions_csv = open(file_path, 'ab')
+        actions_csv_wr = csv.writer(actions_csv, dialect='excel', quoting=csv.QUOTE_ALL)
+    else:
+        actions_csv = open(file_path, 'wb')
+        actions_csv_wr = csv.writer(actions_csv, dialect='excel', quoting=csv.QUOTE_ALL)
+        actions_csv_wr.writerow([
+            'actionId', 'description', 'assignee', 'priority', 'priorityCode', 'status', 'statusCode', 'dueDatetime',
+            'audit', 'auditId', 'linkedToItem', 'linkedToItemId', 'creatorName', 'creatorId', 'createdDatetime',
+            'modifiedDatetime', 'completedDatetime'
+        ])
     for action in actions_array:
         actions_list = transform_action_object_to_list(action)
         actions_csv_wr.writerow(actions_list)

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -42,6 +42,9 @@ SYNC_MARKER_FILENAME = 'last_successful.txt'
 # The file that stores the ISO date/time string of the last successful actions export
 ACTIONS_SYNC_MARKER_FILENAME = 'last_successful_actions_export.txt'
 
+# the file that stores all exported actions in CSV format
+ACTIONS_EXPORT_FILENAME = 'iauditor_actions.csv'
+
 # Whether to export inactive items to CSV
 DEFAULT_EXPORT_INACTIVE_ITEMS_TO_CSV = True
 
@@ -128,13 +131,15 @@ def load_setting_hosting_region(logger, config_settings):
     :return:                 API token if valid, else None
     """
     try:
-        region = config_settings['API']['region'].upper()
+        region = config_settings['API']['region']
+        if region:
+            region = region.upper()
         if region in [USA]:
             logger.debug('Loading region from config file.')
             logger.debug('Setting region to "' + region + '"')
             return region
         else:
-            logger.warning('No valid region specified in config file. Currently only' + USA + 'is supported')
+            logger.info('No valid region specified in config file. Currently only' + USA + 'is supported')
             logger.info('API region defaulting to "' + DEFAULT_HOSTING_REGION + '"')
             return DEFAULT_HOSTING_REGION
     except Exception as ex:
@@ -352,8 +357,7 @@ def save_web_report_link_to_file(logger, export_dir, web_report_data):
 
 def save_exported_actions_to_csv_file(logger, export_path, actions_array):
     """
-    Write Actions to 'AUDIT_ID-actions.csv' on disk at specified location
-    Any existing file with the same name will be overwritten
+    Write Actions to 'iauditor_actions.csv' on disk at specified location
     :param logger:          the logger
     :param export_path:     path to directory for exports
     :param actions_array:   Array of action objects to be converted to CSV and saved to disk
@@ -361,7 +365,7 @@ def save_exported_actions_to_csv_file(logger, export_path, actions_array):
     if not actions_array:
         logger.info('No actions returned after ' + get_last_successful_actions_export(logger))
         return
-    filename = 'iauditor_actions.csv'
+    filename = ACTIONS_EXPORT_FILENAME
     file_path = os.path.join(export_path, filename)
     logger.info('Exporting ' + str(len(actions_array)) + ' actions to ' + file_path)
     file_path = os.path.join(export_path, filename)

--- a/tools/exporter/tests/actions_export_test_files/single_action_from_api.json
+++ b/tools/exporter/tests/actions_export_test_files/single_action_from_api.json
@@ -1,0 +1,30 @@
+{
+  "type": "action",
+  "action_id": "action_9ae9a729d8e34c3cb4536f03ab9598da",
+  "audit": {
+    "audit_id": "audit_5D22B5E98B874035957593DE59290C93",
+    "name": "Mandatory location"
+  },
+  "item": {
+    "item_id": "f3245d43-ea77-11e1-aff1-0800200c9a66",
+    "label": "Prepared by"
+  },
+  "description": "tonys sdk test action",
+  "priority": 10,
+  "status": 0,
+  "assignees": [
+    {
+      "id": "user_fdd054fbf4ef4a069dfc86ff004e7a67",
+      "name": "Tony Oreglia",
+      "type": "user"
+    }
+  ],
+  "created_by": {
+    "user_id": "user_fdd054fbf4ef4a069dfc86ff004e7a67",
+    "name": "Tony Oreglia"
+  },
+  "created_at": "2017-11-15T22:43:19.760Z",
+  "modified_at": "2017-11-15T22:43:19.760Z",
+  "due_at": "2017-11-21T22:40:00.000Z",
+  "completed_at": null
+}

--- a/tools/exporter/tests/actions_export_test_files/single_action_transformed_to_array.json
+++ b/tools/exporter/tests/actions_export_test_files/single_action_transformed_to_array.json
@@ -1,0 +1,19 @@
+[
+  "action_9ae9a729d8e34c3cb4536f03ab9598da",
+  "tonys sdk test action",
+  "Tony Oreglia",
+  "Low",
+  10,
+  "To Do",
+  0,
+  "2017-11-21T22:40:00.000Z",
+  "Mandatory location",
+  "audit_5D22B5E98B874035957593DE59290C93",
+  "Prepared by",
+  "f3245d43-ea77-11e1-aff1-0800200c9a66",
+  "Tony Oreglia",
+  "user_fdd054fbf4ef4a069dfc86ff004e7a67",
+  "2017-11-15T22:43:19.760Z",
+  "2017-11-15T22:43:19.760Z",
+  ""
+]

--- a/tools/exporter/tests/test_actions_exporter.py
+++ b/tools/exporter/tests/test_actions_exporter.py
@@ -1,0 +1,26 @@
+# coding=utf-8
+# Author: SafetyCulture
+# Copyright: © SafetyCulture 2016
+
+import os
+import sys
+import unittest
+import json
+
+sys.path.append(os.path.join(os.path.dirname(__file__), '..', '..', 'exporter'))
+import exporter
+
+class ExporterTestCase(unittest.TestCase):
+    script_dir = os.path.dirname(__file__)
+    relative_path_to_test_files = 'actions_export_test_files/'
+    path_to_test_files = os.path.join(script_dir, relative_path_to_test_files)
+
+    def test_transform_of_action_json_ojbect_to_array(self):
+        example_action_json = json.load(open(os.path.join(self.path_to_test_files, 'single_action_from_api.json'), 'r'))
+        single_action_transformed_to_array = json.load(open(os.path.join(self.path_to_test_files, 'single_action_transformed_to_array.json'), 'r'))
+        actual_action_transformed_to_array = exporter.transform_action_object_to_list(example_action_json)
+        self.assertEqual(single_action_transformed_to_array, actual_action_transformed_to_array)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Improvements to iAuditor actions CSV export.

1. The header columns are no longer printed each time actions are exported
2. Actions that are completed are now re-exported with the date completed. 

For example, if an actions is created, exported, then completed, the action would be appended to the CSV file twice: 


actionId | description | assignee | priority | priorityCode | status | statusCode | dueDatetime | audit | auditId | linkedToItem | linkedToItemId | creatorName | creatorId | createdDatetime | modifiedDatetime | completedDatetime
-- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | -- | --
action_0f86dd07d92b459dba25994f2210318e | test action | Tony Oreglia | None | 0 | To Do | 0 |   | Mandatory location | audit_5D22B5E98B874035957593DE59290C93 | Location | f3245d44-ea77-11e1-aff1-0800200c9a66 | Tony Oreglia | user_fdd054fbf4ef4a069dfc86ff004e7a67 | 2017-11-15T23:17:25.746Z | 2017-11-15T23:17:25.746Z |  
action_56effb4193534b97ad0618c804bf6fd5 | test action |   | None | 0 | Done | 50 |   | all types of fields | audit_08d25c119a424037812332f05c24c481 | this question is using a global response set! don't answer hi | 07027a06-daeb-4193-9743-40d4be310d6d | Tony Oreglia | user_fdd054fbf4ef4a069dfc86ff004e7a67 | 2017-10-18T00:05:53.829Z | 2017-11-15T23:18:44.167Z | 2017-11-15T23:18:43.414Z


Added a unit test to cover the functionality of actions export function: transform_of_action_json_ojbect_to_array()
