### PR TITLE
INTG-1009_revert to using audit_data.name for naming export by audit title

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,8 @@ Note: Templates for which there is no export profile id listed in the config fil
 
 ### Naming the exported files
 
+Note that the Audit Title field has been deprecated by SafetyCulture in favour of the Audit Title Rule. However, setting Audit Title as the export filename will still work for audits using the new Audit Title Rule functionality.
+
 When configuring a custom filename convention in export settings (in `config.yaml`) you can provide an audit item ID from the ones below to cause all exported audit reports be named after the response of that particular item in the audit.
 
 Here are some standard item IDs

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ Note: Templates for which there is no export profile id listed in the config fil
 
 ### Naming the exported files
 
-Note that the Audit Title field has been deprecated by SafetyCulture in favour of the Audit Title Rule. However, setting Audit Title as the export filename will still work for audits using the new Audit Title Rule functionality.
+Note that when automatic Audit Title rules are set on the template, the Audit will not contain an Audit Title field by default. Regardless, the export filename setting will still work as expected using the automatically generated Audit name.
 
 When configuring a custom filename convention in export settings (in `config.yaml`) you can provide an audit item ID from the ones below to cause all exported audit reports be named after the response of that particular item in the audit.
 

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -70,7 +70,7 @@ EXPORT_FORMATS = 'export_formats'
 DEFAULT_CONFIG_FILE_YAML = [
     'API:',
     '\n    token: ',
-    '\nexport_options:',
+    '\nexport_options:',    
     '\n    export_path:',
     '\n    timezone:',
     '\n    filename:',
@@ -504,7 +504,6 @@ def parse_export_filename(audit_json, filename_item_id):
     # Not all Audits will actually contain an Audit Title item. For examples, when Audit Title rules are set, the Audit Title item is not going to be included by default.
     # When this item ID is specified in the custom export filename configuration, the audit_data.name property will be used to populate the data as it covers all cases.
     if filename_item_id == AUDIT_TITLE_ITEM_ID and 'audit_data' in audit_json.keys() and 'name' in audit_json['audit_data'].keys():
-        print('I am returning the audit data name: ' + audit_json['audit_data']['name'])
         return audit_json['audit_data']['name'].replace('/','_')
     for item in audit_json['header_items']:
         if item['item_id'] == filename_item_id:

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -500,7 +500,8 @@ def parse_export_filename(audit_json, filename_item_id):
     """
     if filename_item_id is None:
         return None
-    # Audit title header item has been deprecated by SafetyCulture. Audit title now stored in audit_data.name property.
+    # Not all Audits will actually contain an Audit Title item. For examples, when Audit Title rules are set, the Audit Title item is not going to be included by default.
+    # When this item ID is specified in the custom export filename configuration, the audit_data.name property will be used to populate the data as it covers all cases.
     if filename_item_id == AUDIT_TITLE_ITEM_ID and 'audit_data' in audit_json.keys() and 'name' in audit_json['audit_data'].keys():
         print('I am returning the audit data name: ' + audit_json['audit_data']['name'])
         return audit_json['audit_data']['name'].replace('/','_')

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -51,7 +51,8 @@ DEFAULT_EXPORT_INACTIVE_ITEMS_TO_CSV = True
 # When exporting actions to CSV, if property is None, print this value to CSV
 EMPTY_RESPONSE = ''
 
-# If user specifies this for the export filename, the audit_data.name property is used.
+# Not all Audits will actually contain an Audit Title item. For examples, when Audit Title rules are set, the Audit Title item is not going to be included by default.
+# When this item ID is specified in the custom export filename configuration, the audit_data.name property will be used to populate the data as it covers all cases.
 AUDIT_TITLE_ITEM_ID = 'f3245d40-ea77-11e1-aff1-0800200c9a66'
 
 # Properties kept in settings dictionary which takes its values from config.YAML


### PR DESCRIPTION
Python SDK allows customers to name their export filenames by header items. However, the audit title header item has been deprecated in favour of the audit title rule. 
If the customer sets up the config file to use the audit title for the export filename. e.g.
```
API:
    token:
export_options:
    export_path:
    timezone:
    filename: f3245d40-ea77-11e1-aff1-0800200c9a66
    csv_options:
        export_inactive_items: false
    export_profiles:
    sync_delay_in_seconds: 10
    media_sync_offset_in_seconds: 10
```

this code uses the value in `audit_json.audit_data.name` rather than parsing out the audit title from the list of header items. 

`/` values are replaced with `_` to avoid file path issues. 

```
iauditor-exporter --format pdf
```

[31 Jul 2018 _ Tony Oreglia.pdf](https://github.com/SafetyCulture/safetyculture-sdk-python/files/2244129/31.Jul.2018._.Tony.Oreglia.pdf)
