### PR TITLE
fix to allow JSON extracts to work again

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name = 'safetyculture-sdk-python',
-      version = '3.3.0',
+      version = '3.3.1',
       description = 'iAuditor Python SDK and integration tools',
       url = 'https://github.com/SafetyCulture/safetyculture-sdk-python',
       author = 'SafetyCulture',

--- a/tools/exporter/exporter.py
+++ b/tools/exporter/exporter.py
@@ -758,7 +758,7 @@ def sync_exports(logger, settings, sc_client):
     """
     if 'actions' in settings[EXPORT_FORMATS]:
         export_actions(logger, settings, sc_client)
-    if not bool(set(settings[EXPORT_FORMATS]) & {'pdf', 'docx', 'csv', 'media', 'web-report-link'}):
+    if not bool(set(settings[EXPORT_FORMATS]) & {'pdf', 'docx', 'csv', 'media', 'web-report-link', 'json'}):
         return
     last_successful = get_last_successful(logger)
     list_of_audits = sc_client.discover_audits(modified_after=last_successful)
@@ -852,7 +852,7 @@ def export_audit_json(logger, settings, audit_json, export_filename):
     """
     export_format = 'json'
     export_doc = json.dumps(audit_json, indent=4)
-    save_exported_document(logger, settings[EXPORT_PATH], export_doc, export_filename, export_format)
+    save_exported_document(logger, settings[EXPORT_PATH], export_doc.encode(), export_filename, export_format)
 
 
 def export_audit_csv(settings, audit_json):


### PR DESCRIPTION
Had to update the export type check to allow for the JSON parameter as per the documentation.

Updated the JSON extractor class to pass the JSON data encoded rather than as a string as the writing function expected bytecode when writing PDF files.

I have only been able to test this on Python3 so I am unsure if str.encode() will work the same on Python2.
