### PR TITLE
SKB-3265 add long_description_content_type to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,7 @@ setup(name = 'safetyculture-sdk-python',
             ],
       },
       long_description=open('README.md', 'r').read(),
+      long_description_content_type="text/markdown",
       install_requires = [
             'python-dateutil>=2.5.0',
             'pytz>=2015.7',


### PR DESCRIPTION
added glong_description_content_type to setup.py with the value of 'text/markdown' so that PyPi will process the package correctly.