### PR TITLE
[CC-35] Add logger to cvsExporter

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name = 'safetyculture-sdk-python',
-      version = '4.0.0',
+      version = '4.1.0',
       description = 'iAuditor Python SDK and integration tools',
       url = 'https://github.com/SafetyCulture/safetyculture-sdk-python',
       author = 'SafetyCulture',

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup
 
 setup(name = 'safetyculture-sdk-python',
-      version = '4.1.0',
+      version = '4.1.1',
       description = 'iAuditor Python SDK and integration tools',
       url = 'https://github.com/SafetyCulture/safetyculture-sdk-python',
       author = 'SafetyCulture',

--- a/tools/exporter/csvExporter.py
+++ b/tools/exporter/csvExporter.py
@@ -383,8 +383,8 @@ class CsvExporter:
             wr = csv.writer(csv_file, dialect='excel', quoting=csv.QUOTE_ALL)
             wr.writerows(self.audit_table)
             csv_file.close()
-        except Exception as ex:
-            csvExporter_logger.exception(('Error saving audit_table to ' + output_csv_path)
+        except Exception:
+            csvExporter_logger.exception('Error saving audit_table to ' + output_csv_path)
 
     def get_item_response(self, item):
         """
@@ -437,7 +437,7 @@ class CsvExporter:
             try:
                 csvExporter_logger.error('Unhandled item type: ' + str(item_type) + ' from ' +
                   self.audit_id() + ', ' + item.get(ID))
-            except Exception as ex:
+            except Exception:
                 csvExporter_logger.exception('Error parsing item, item likely malformed')
             
         return response

--- a/tools/exporter/csvExporter.py
+++ b/tools/exporter/csvExporter.py
@@ -203,7 +203,6 @@ class CsvExporter:
         sh.setLevel(log_level)
         sh.setFormatter(formatter)
         csvExporter_logger.addHandler(sh)
-        csvExporter_logger.error('log it!')
 
     def audit_id(self):
         """

--- a/tools/exporter/csvExporter.py
+++ b/tools/exporter/csvExporter.py
@@ -1,5 +1,6 @@
 import unicodecsv as csv
 import json
+import logging
 import sys
 import os
 import copy
@@ -174,12 +175,35 @@ class CsvExporter:
 
         :param audit_json:      audit in JSON format to be converted to CSV
         """
+        self.configure_logging()
         self.audit_json = audit_json
         self.export_inactive_items = export_inactive_items
         self.item_category = EMPTY_RESPONSE
         self.item_map = {}
         self.map_items()
         self.audit_table = self.convert_audit_to_table()
+
+    def configure_logging(self):
+        """
+        Configure logging to log to std output as well as to log file
+        """
+        log_level = logging.DEBUG
+
+        log_filename = datetime.now().strftime('%Y-%m-%d') + '.log'
+        csvExporter_logger = logging.getLogger('csvExporter_logger')
+        csvExporter_logger.setLevel(log_level)
+        formatter = logging.Formatter('%(asctime)s : %(levelname)s : %(message)s')
+
+        fh = logging.FileHandler(filename=os.getcwd() + log_filename)
+        fh.setLevel(log_level)
+        fh.setFormatter(formatter)
+        csvExporter_logger.addHandler(fh)
+
+        sh = logging.StreamHandler(sys.stdout)
+        sh.setLevel(log_level)
+        sh.setFormatter(formatter)
+        csvExporter_logger.addHandler(sh)
+        csvExporter_logger.error('log it!')
 
     def audit_id(self):
         """
@@ -353,13 +377,14 @@ class CsvExporter:
         :param output_csv_path: the full path to file to save
         :param mode:    write ('wb') or append ('ab') mode
         """
+        csvExporter_logger = logging.getLogger('csvExporter_logger')
         try:
             csv_file = open(output_csv_path, mode)
             wr = csv.writer(csv_file, dialect='excel', quoting=csv.QUOTE_ALL)
             wr.writerows(self.audit_table)
             csv_file.close()
         except Exception as ex:
-            print(str(ex) + ': Error saving audit_table to ' + output_csv_path)
+            csvExporter_logger.exception(('Error saving audit_table to ' + output_csv_path)
 
     def get_item_response(self, item):
         """
@@ -367,6 +392,7 @@ class CsvExporter:
         :param item:    single item in JSON format
         :return:        response property
         """
+        csvExporter_logger = logging.getLogger('csvExporter_logger')
         response = EMPTY_RESPONSE
         item_type = get_json_property(item, TYPE)
         if item_type == 'question':
@@ -407,8 +433,13 @@ class CsvExporter:
                            INFORMATION]:
             pass
         else:
-            print('Unhandled item type: ' + str(item_type) + ' from ' +
+            # No item type might mean malformed item object, catch and log error accessing item
+            try:
+                csvExporter_logger.error('Unhandled item type: ' + str(item_type) + ' from ' +
                   self.audit_id() + ', ' + item.get(ID))
+            except Exception as ex:
+                csvExporter_logger.exception('Error parsing item, item likely malformed')
+            
         return response
 
     @staticmethod


### PR DESCRIPTION
Customer reported the CSV exporter was throwing an error and exiting. Investigation showed that this was due to two issues:

1. There was no logging for this file whatsoever
2. The user was encountering a malformed inspection item in the JSON file

To resolve this I have:

1. Add in the python logger
2. Updated the existing Try/Catch to use the logger
3. Added a new Try/Catch for the rare scenario that the customer experienced

This should provide the csvExporter with more resilience and add additional logging in the event of future unforeseen errors.