### PR TITLE
[CSR-744] - Fix for odd None values in media arrays

### DIFF
--- a/tools/exporter/csvExporter.py
+++ b/tools/exporter/csvExporter.py
@@ -560,7 +560,12 @@ class CsvExporter:
         elif item_type in ['drawing', SIGNATURE]:
             media_href = get_json_property(item, RESPONSES, 'image', HREF)
         else:
-            media_href = '\n'.join(image[HREF] for image in get_json_property(item, MEDIA))
+            media_list = []
+            for image in get_json_property(item, MEDIA):
+                if image:
+                    media_list.append(image[HREF])
+            media_href = '\n'.join(media_list)
+
         return media_href
 
     @staticmethod


### PR DESCRIPTION
In the original Python exporter, if the media array of an item is "None", the script fails. In the example reported, the JSON was returning a media array like this: `'media': [None]`

I've changed the way this is handled so the script now checks if the media array is present.